### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Looking for free Telegram bot hosting? Here's a curated list of platforms with l
 | [Alwaysdata](https://www.alwaysdata.com/) | 🟢 Working | 100 MB storage with MySQL, PostgreSQL, CouchDB, MongoDB, PHP, Python, Ruby, Node.js, Elixir, Java, Deno, custom web servers, access via FTP, WebDAV and SSH |
 | [Claw.Cloud](https://ap-southeast-1.run.claw.cloud/signin) | 🟢 Working | $5/month free credits for users with a GitHub account older than 180 days. |
 | [Lade.io](https://lade.io) | 🔴 Not Working | Free tier seems discontinued or inactive |
-| [Leapcell](https://leapcell.io) | 🟢 Working | 3 VCPUs, 4GB Ram, 10000 async tasks, 100000 redis commands. |
 | [Serv00](https://serv00.com) | 🟢 Working | Offers shell access; can run Python, Ruby, Perl, Java, TCL/TK, Lua, Erlang, Rust, Go, C, C++, D, R bots using screen or tmux; 3GB ssd, 512MB RAM |
 | [Sevalla](https://sevalla.com) | 🟢 Working | $50 free credit on new signup. |
 


### PR DESCRIPTION
This site can barely run a Telegram bot, as it only supports HTTP services and doesn’t support long connections.